### PR TITLE
fix(react-i18n): fix components call to t function

### DIFF
--- a/packages/react-i18n/src/components/i18nElement.component.js
+++ b/packages/react-i18n/src/components/i18nElement.component.js
@@ -4,7 +4,7 @@ import { Context } from '../context/i18n.context';
 
 export const HtmlTrans = ({ i18nKey, data, number, general, element: Element, renderers, ...props }) => (
   <Context.Consumer>
-    {t => <Element {...props} dangerouslySetInnerHTML={{ __html: t(i18nKey, data, number, general, renderers) }} />}
+    {t => <Element {...props} dangerouslySetInnerHTML={{ __html: t(i18nKey, { data, number, general, renderers }) }} />}
   </Context.Consumer>
 );
 

--- a/packages/react-i18n/src/components/i18nString.component.js
+++ b/packages/react-i18n/src/components/i18nString.component.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Context } from './../context/i18n.context';
+import { Context } from '../context/i18n.context';
 
 export const Trans = ({ i18nKey, data, number, general, renderers }) => (
-  <Context.Consumer>{t => t(i18nKey, data, number, general, renderers)}</Context.Consumer>
+  <Context.Consumer>{t => t(i18nKey, { data, number, general, renderers })}</Context.Consumer>
 );
 
 Trans.defaultProps = {


### PR DESCRIPTION
Fix a bug when using <Trans /> component.

Signature for the translate function changed but its call from Trans and HtmlTrans components didn't.