### PR TITLE
chore(react-i18n): disable sideEffect to allow webpack tree-shaking

### DIFF
--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -43,6 +43,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "sideEffects": false,
   "scripts": {
     "babel-watch": "babel src --out-dir lib --watch --ignore __tests__,__mocks__",
     "build": "yarn build:commonjs && yarn build:es",


### PR DESCRIPTION
## 🤔 Why?

When requiring the lib, webpack can't do its [tree-shaking](https://webpack.js.org/guides/tree-shaking/) properly because of the commonjs require.

The problem I face is that, I need to import the translateFunction but I can't require it because when Webpack require the whole lib Next.JS throws an error because of the createContext used elsewhere in the lib. If we enable the treeshaking, only the function that I need will be imported and Next.JS won't throw an error.

## 💻 How?

<!--
Describe the changes you made in the PR, changes in directory/tree, installed dependencies.
You could also self comment your diff to help reviewer understand them.

ℹ️ made this change to ...
-->

- Added the property `sideEffects: false` in the package.json of react-i18n as specified in [the webpack doc](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)

