### PR TITLE
chore(deps): cleanup lodash imports and add it as peer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ coverage/
 **/node_modules/
 **/es/
 **/lib/
-
-

--- a/packages/eslint-plugin-i18n/src/rules/interpolation-data.js
+++ b/packages/eslint-plugin-i18n/src/rules/interpolation-data.js
@@ -1,4 +1,5 @@
-const _ = require('lodash');
+// eslint-disable-next-line no-underscore-dangle
+const _get = require('lodash/get');
 const { getKeyValue, get, getLangConfig, getTranslateParams, isFileIgnored } = require('../utils/utils');
 
 const check = ({ key, countNode, dataNode, config, context, node }) => {
@@ -67,8 +68,8 @@ module.exports = {
 
     return {
       JSXOpeningElement(node) {
-        const nodeName = _.get(node, 'name.name', null);
-        const nodeAttributes = _.get(node, 'attributes', null);
+        const nodeName = _get(node, 'name.name', null);
+        const nodeAttributes = _get(node, 'attributes', null);
 
         if (nodeName === 'Trans') {
           const filteredAttributes = Object.values(nodeAttributes).reduce(

--- a/packages/eslint-plugin-i18n/src/rules/no-unknown-key.js
+++ b/packages/eslint-plugin-i18n/src/rules/no-unknown-key.js
@@ -1,4 +1,5 @@
-const _ = require('lodash');
+// eslint-disable-next-line no-underscore-dangle
+const _get = require('lodash/get');
 const { getKeyValue, get, has, getLangConfig, getTranslateParams, isFileIgnored } = require('../utils/utils');
 
 const check = ({ key, countNode, config, langsKey, context, node }) => {
@@ -63,8 +64,8 @@ module.exports = langsKey => ({
 
     return {
       JSXOpeningElement(node) {
-        const nodeName = _.get(node, 'name.name', null);
-        const nodeAttributes = _.get(node, 'attributes', null);
+        const nodeName = _get(node, 'name.name', null);
+        const nodeAttributes = _get(node, 'attributes', null);
         if (nodeName === 'Trans') {
           const filteredAttributes = Object.values(nodeAttributes).reduce(
             (acc, attribute) =>

--- a/packages/i18n-lint/src/runner.js
+++ b/packages/i18n-lint/src/runner.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import _find from 'lodash/find';
+import _flatMap from 'lodash/flatMap';
+import _merge from 'lodash/merge';
 import Reader from './reader';
 import ConfigLoader from './configLoader';
 import { validateHTML } from './verifiers/htmlVerifier';
@@ -16,7 +18,7 @@ export default class Runner {
     const configIndex = process.argv.indexOf('--config') + 1;
     if (configIndex < process.argv.length && configIndex > 0) {
       configPath = process.argv[configIndex];
-      this.config = _.merge(config, ConfigLoader.load(configPath));
+      this.config = _merge(config, ConfigLoader.load(configPath));
     } else {
       this.config = config;
     }
@@ -29,12 +31,12 @@ export default class Runner {
       },
     } = this.config;
 
-    const reports = _.flatMap([...principalLangs, ...secondaryLangs], ({ name, translationPath }) => {
+    const reports = _flatMap([...principalLangs, ...secondaryLangs], ({ name, translationPath }) => {
       const tradForLang = Reader.parse(translationPath);
 
-      return _.flatMap(reporters, (reporter) => reporter(tradForLang, name));
+      return _flatMap(reporters, (reporter) => reporter(tradForLang, name));
     });
 
-    process.exit(_.find(reports, { error: true }) ? 1 : 0);
+    process.exit(_find(reports, { error: true }) ? 1 : 0);
   }
 }

--- a/packages/i18n-lint/src/verifiers/htmlVerifier.js
+++ b/packages/i18n-lint/src/verifiers/htmlVerifier.js
@@ -1,4 +1,7 @@
-import _ from 'lodash';
+import _countBy from 'lodash/countBy';
+import _every from 'lodash/every';
+import _forEach from 'lodash/forEach';
+import _mergeWith from 'lodash/mergeWith';
 import isHtml from 'is-html';
 import { flatten } from '../utils';
 import { info } from '../logger';
@@ -19,20 +22,20 @@ const noMissingTag = string => {
   const openTags = [];
   const closedTags = [];
 
-  _.forEach(getMatches(string, /<(\w+)[^/]*>/g, 1), tag => {
+  _forEach(getMatches(string, /<(\w+)[^/]*>/g, 1), tag => {
     openTags.push(tag);
   });
 
-  _.forEach(getMatches(string, /<\/([a-zA-Z]+)>/g, 1), tag => {
+  _forEach(getMatches(string, /<\/([a-zA-Z]+)>/g, 1), tag => {
     closedTags.push(tag);
   });
 
-  const tags = _.mergeWith(_.countBy(openTags), _.countBy(closedTags), (objValue, srcValue) => ({
+  const tags = _mergeWith(_countBy(openTags), _countBy(closedTags), (objValue, srcValue) => ({
     open: objValue || 0,
     closed: srcValue || 0,
   }));
 
-  return _.every(tags, tag => tag.open && tag.closed && tag.open === tag.closed);
+  return _every(tags, tag => tag.open && tag.closed && tag.open === tag.closed);
 };
 
 const rules = {
@@ -58,8 +61,8 @@ export const validateHTML = (jsonTree, lang, isError = true) => {
   const reports = [];
 
   info(`Starting lang ${lang.toUpperCase()} \n`);
-  _.forEach(flatten(jsonTree), (value, key) =>
-    _.forEach(rules, ({ test, message }) => {
+  _forEach(flatten(jsonTree), (value, key) =>
+    _forEach(rules, ({ test, message }) => {
       if (!test(value)) {
         reports.push(reportBuilder(lang, key, message, value, isError));
       }

--- a/packages/i18n-lint/src/verifiers/jsonVerifier.js
+++ b/packages/i18n-lint/src/verifiers/jsonVerifier.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _flatMap from 'lodash/flatMap';
 import { reportBuilder } from '../reporters/reportBuilder';
 
 const alphabeticRule = (lang, nodeIdentifier, nodeIndex, jsonEntry, keys) => {
@@ -24,8 +24,8 @@ const rules = [alphabeticRule];
 export const validateJson = (jsonTree, lang) => {
   const keys = Object.keys(jsonTree);
 
-  return _.flatMap(keys, (nodeIdentifier, nodeIndex) => {
-    const nextState = _.flatMap(rules, rule => rule(lang, nodeIdentifier, nodeIndex, jsonTree, keys));
+  return _flatMap(keys, (nodeIdentifier, nodeIndex) => {
+    const nextState = _flatMap(rules, rule => rule(lang, nodeIdentifier, nodeIndex, jsonTree, keys));
     const currentNode = jsonTree[nodeIdentifier];
 
     if (typeof currentNode === 'object') {

--- a/packages/react-i18n/.babelrc
+++ b/packages/react-i18n/.babelrc
@@ -11,8 +11,7 @@
       "presets": [["env", { "modules": "commonjs" }]]
     },
     "es": {
-      "presets": [["env", { "modules": false }]],
-      "plugins": ["lodash", "use-lodash-es"]
+      "presets": [["env", { "modules": false }]]
     }
   },
   "presets": [

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -13,6 +13,7 @@
     "types.d.ts"
   ],
   "peerDependencies": {
+    "lodash": "^4.17.0",
     "prop-types": "^15.7.1",
     "react": "^16.8.0 || ^17.0.0"
   },
@@ -22,22 +23,19 @@
   "devDependencies": {
     "@wojtekmaj/enzyme-adapter-react-17": "0.8.0",
     "babel-cli": "6.26.0",
-    "babel-plugin-lodash": "3.3.4",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
-    "babel-plugin-use-lodash-es": "^0.2.0",
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
     "enzyme": "3.8.0",
     "enzyme-to-json": "3.3.5",
     "jest": "23.6.0",
-    "lodash-es": "4.17.14",
+    "lodash": "4.17.21",
     "prop-types": "15.7.1",
     "react": "17.0.2",
     "react-addons-test-utils": "15.6.2",
     "react-dom": "17.0.2"
   },
   "dependencies": {
-    "lodash": "4.17.19",
     "sprintf-js": "1.1.2"
   },
   "publishConfig": {

--- a/packages/react-i18n/src/utils/html.utils.js
+++ b/packages/react-i18n/src/utils/html.utils.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import _compact from 'lodash/compact';
 
 const upperCase = /^[A-Z]/;
 const tagSearch = /(<.+?>)/;
@@ -136,7 +136,7 @@ const renderer = (tree, renderers = {}) => {
 };
 
 export const interpolateHTMLTags = (translation, renderers) => {
-  const tags = _.compact(translation.split(tagSearch), x => x !== '').reduce(
+  const tags = _compact(translation.split(tagSearch), x => x !== '').reduce(
     (acc, element) => acc.concat(element[0] === '<' ? analyseTag(element) : element),
     [],
   );

--- a/packages/react-i18n/src/utils/i18n.utils.js
+++ b/packages/react-i18n/src/utils/i18n.utils.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import _get from 'lodash/get';
+import _has from 'lodash/has';
+import _noop from 'lodash/noop';
 import { sprintf } from 'sprintf-js';
 import { interpolateHTMLTags } from './html.utils';
 
@@ -37,8 +39,8 @@ const pluralizeFunctions = {
   nl: number => (number === 1 ? 'one' : 'other'),
 };
 
-export const translate = (lang, i18nNames = {}, errorCallback = _.noop, parseHTML = false) => {
-  const pluralize = pluralizeFunctions[_.get(lang, '_i18n.lang')] || pluralizeFunctions.fr;
+export const translate = (lang, i18nNames = {}, errorCallback = _noop, parseHTML = false) => {
+  const pluralize = pluralizeFunctions[_get(lang, '_i18n.lang')] || pluralizeFunctions.fr;
 
   return (key, { data = {}, number, general, renderers } = {}) => {
     let combineKey = key;
@@ -48,8 +50,8 @@ export const translate = (lang, i18nNames = {}, errorCallback = _.noop, parseHTM
     }
 
     let translation;
-    if (_.has(lang, combineKey)) {
-      translation = _.get(lang, combineKey);
+    if (_has(lang, combineKey)) {
+      translation = _get(lang, combineKey);
     } else {
       errorCallback(combineKey);
       translation = combineKey;
@@ -67,8 +69,8 @@ export const translate = (lang, i18nNames = {}, errorCallback = _.noop, parseHTM
 };
 
 export const buildList = lang => (list, maxSize) => {
-  const separator = _.get(lang, '_i18n.separator');
-  const lastSeparator = _.get(lang, '_i18n.and');
+  const separator = _get(lang, '_i18n.separator');
+  const lastSeparator = _get(lang, '_i18n.and');
 
   if (!list || !list.length) {
     return '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,13 +56,6 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-module-imports@^7.0.0-beta.49":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.54.tgz#c2d8e14ff034225bf431356db77ef467b8d35aac"
-  dependencies:
-    "@babel/types" "7.0.0-beta.54"
-    lodash "^4.17.5"
-
 "@babel/helper-plugin-utils@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
@@ -128,14 +121,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.10"
-
-"@babel/types@7.0.0-beta.54", "@babel/types@^7.0.0-beta.49":
-  version "7.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.54.tgz#025ad68492fed542c13f14c579a44c848e531063"
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.5"
-    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.0.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.2":
   version "7.3.2"
@@ -1709,16 +1694,6 @@ babel-plugin-jest-hoist@^24.1.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.1.0.tgz#dfecc491fb15e2668abbd690a697a8fd1411a7f8"
   integrity sha512-gljYrZz8w1b6fJzKcsfKsipSru2DU2DmQ39aB6nV3xQ0DDv3zpIzKGortA5gknrhNnPN8DweaEgrnZdmbGmhnw==
 
-babel-plugin-lodash@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0-beta.49"
-    "@babel/types" "^7.0.0-beta.49"
-    glob "^7.1.1"
-    lodash "^4.17.10"
-    require-package-name "^2.0.1"
-
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -1981,10 +1956,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
-
-babel-plugin-use-lodash-es@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-use-lodash-es/-/babel-plugin-use-lodash-es-0.2.0.tgz#252ba9d68a6c1758be947e9a88b0064ecf8351d7"
 
 babel-polyfill@^6.26.0:
   version "6.26.0"
@@ -6303,11 +6274,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@4.17.14:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.14.tgz#12a95a963cc5955683cee3b74e85458954f37ecc"
-  integrity sha512-7zchRrGa8UZXjD/4ivUWP1867jDkhzTG2c/uj739utSd7O/pFFdxspCemIFKEEjErbcqRzn8nKnGsi7mvTgRPA==
-
 lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -6375,7 +6341,7 @@ lodash@4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@4.17.21, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8467,10 +8433,6 @@ require-directory@^2.1.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-
-require-package-name@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
 
 require-relative@^0.8.7:
   version "0.8.7"


### PR DESCRIPTION
Remove old and deprecated configuration of webpack for lodash tree shaking.
Just import the used function from lodash to prevent it to being fully loaded in projects.
Move lodash import to package's peer dependencies to allow different version in projects.