### PR TITLE
chore(deps): widen the peerDependencies in the package.json's

### DIFF
--- a/packages/eslint-plugin-i18n/package.json
+++ b/packages/eslint-plugin-i18n/package.json
@@ -18,7 +18,7 @@
     "sinon": "7.2.3"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": ">=4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -14,7 +14,7 @@
   ],
   "peerDependencies": {
     "prop-types": "^15.7.1",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "jest": {
     "timers": "fake"


### PR DESCRIPTION
## 🤔 Why?
When using theses packages with our app. The peerDependencies resolutions makes our package manager warn us about unmet peerDependencies. 

We want to be able to use react-i18n with React 18.

We want to be able to use eslint-plugin-i18n.

<!--
Explain here why the repository need this change, explain the US with your own words.
In case of technical user story, this is more than mandatory.

You could specify:
- links to updated library changelog
- links to related documentation/discussion
-->

## 💻 How?

We widen the peerDependencies specifier:
- We want to allow React 18 to work with react-i18n with '|| ^18.0.0'
- We want to allow any Eslint version above 4.0.0

<!--
Describe the changes you made in the PR, changes in directory/tree, installed dependencies.
You could also self comment your diff to help reviewer understand them.

ℹ️ made this change to ...
-->