### PR TITLE
fix: cover edge cases for anchor tags

### DIFF
--- a/packages/i18n-lint/src/verifiers/__tests__/__snapshots__/htmlVerifier.spec.js.snap
+++ b/packages/i18n-lint/src/verifiers/__tests__/__snapshots__/htmlVerifier.spec.js.snap
@@ -40,7 +40,3 @@ Array [
   },
 ]
 `;
-
-exports[`validateHTML should validate anchor with interpolated href value 1`] = `Array []`;
-
-exports[`validateHTML should validate anchor with static href value 1`] = `Array []`;

--- a/packages/i18n-lint/src/verifiers/__tests__/__snapshots__/htmlVerifier.spec.js.snap
+++ b/packages/i18n-lint/src/verifiers/__tests__/__snapshots__/htmlVerifier.spec.js.snap
@@ -40,3 +40,7 @@ Array [
   },
 ]
 `;
+
+exports[`validateHTML should validate anchor with interpolated href value 1`] = `Array []`;
+
+exports[`validateHTML should validate anchor with static href value 1`] = `Array []`;

--- a/packages/i18n-lint/src/verifiers/__tests__/htmlVerifier.spec.js
+++ b/packages/i18n-lint/src/verifiers/__tests__/htmlVerifier.spec.js
@@ -3,7 +3,7 @@ import { validateHTML } from '../htmlVerifier';
 jest.unmock('../htmlVerifier');
 
 const tests = {
-  firstTag: 'foo <div> foo',
+  firstTag: 'foo <a> foo',
   lastTag: 'foo </div> foo',
   control: '<div> foo </div>',
   doubleSpace: 'foo  bar',
@@ -17,5 +17,15 @@ const tests = {
 describe('validateHTML', () => {
   it('should detect html errors', () => {
     expect(validateHTML(tests, 'test', true)).toMatchSnapshot();
+  });
+
+  it('should validate anchor with static href value', () => {
+    expect(validateHTML({ validAnchor: '<a href="http://localhost">foo</a>' }, 'test', true)).toMatchSnapshot();
+  });
+
+  it('should validate anchor with interpolated href value', () => {
+    expect(
+      validateHTML({ validAnchor: '<a href="%(googlePrivacyUrl)s">Règles de confidentialité</a>' }, 'test', true),
+    ).toMatchSnapshot();
   });
 });

--- a/packages/i18n-lint/src/verifiers/__tests__/htmlVerifier.spec.js
+++ b/packages/i18n-lint/src/verifiers/__tests__/htmlVerifier.spec.js
@@ -20,12 +20,12 @@ describe('validateHTML', () => {
   });
 
   it('should validate anchor with static href value', () => {
-    expect(validateHTML({ validAnchor: '<a href="http://localhost">foo</a>' }, 'test', true)).toMatchSnapshot();
+    expect(validateHTML({ validAnchor: '<a href="https://www.m6.fr/html5">foo</a>' }, 'test', true)).toHaveLength(0);
   });
 
   it('should validate anchor with interpolated href value', () => {
     expect(
       validateHTML({ validAnchor: '<a href="%(googlePrivacyUrl)s">Règles de confidentialité</a>' }, 'test', true),
-    ).toMatchSnapshot();
+    ).toHaveLength(0);
   });
 });

--- a/packages/i18n-lint/src/verifiers/htmlVerifier.js
+++ b/packages/i18n-lint/src/verifiers/htmlVerifier.js
@@ -11,7 +11,7 @@ const getMatches = (string, regex, index = 1) => {
   const matches = [];
   let match = regex.exec(string);
   while (match) {
-    matches.push(match[index]);
+    matches.push(match[index] ? match[index] : match[match.length - 1]);
     match = regex.exec(string);
   }
 
@@ -22,7 +22,7 @@ const noMissingTag = string => {
   const openTags = [];
   const closedTags = [];
 
-  _forEach(getMatches(string, /<(\w+)[^/]*>/g, 1), tag => {
+  _forEach(getMatches(string, /<(\w+)[^/]*>|<(a)\s+href="\S+"[^/]*>/g, 1), tag => {
     openTags.push(tag);
   });
 


### PR DESCRIPTION
### Why?

At bedrock we want to add translations with a static href value and the current linter never captures the open anchor tag.

eg: '<a href="http://www.m6.fr/html5">some link</a>' will fail because it won't have a open tag captured

### How?

Add a second capture group just for this case