### PR TITLE
feat(react-i18n): add possibility to make german plural

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage/
 **/node_modules/
 **/es/
 **/lib/
+
+.idea/

--- a/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
+++ b/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
@@ -100,6 +100,17 @@ describe('i18n translate function', () => {
       expect(t('foo.bar', {number: 1, general: true})).toBe('foo bar!');
       expect(t('foo.bar', {number: 2, general: true})).toBe('foos bars!!!');
     });
+
+    it('should pluralize in german', () => {
+      const lang = {
+        foo: { bar: { one: 'foo bar!', other: 'foos bars!!!' } },
+        _i18n: { lang: 'de' },
+      };
+      const t = translate(lang);
+      expect(t('foo.bar', {number: 0, general: true})).toBe('foos bars!!!');
+      expect(t('foo.bar', {number: 1, general: true})).toBe('foo bar!');
+      expect(t('foo.bar', {number: 2, general: true})).toBe('foos bars!!!');
+    });
   });
 
   describe('with number interpolation', () => {

--- a/packages/react-i18n/src/utils/i18n.utils.js
+++ b/packages/react-i18n/src/utils/i18n.utils.js
@@ -5,6 +5,7 @@ import { sprintf } from 'sprintf-js';
 import { interpolateHTMLTags } from './html.utils';
 
 const pluralizeFunctions = {
+  de: number => (number === 1 ? 'one' : 'other'),
   en: number => (number === 1 ? 'one' : 'other'),
   fr: number => (number > 1 ? 'other' : 'one'),
   hr: (number, general) => {


### PR DESCRIPTION
## 🤔 Why?

I want to use i18n with German from Germany. As such, I need to be able to handle plurals. Basing myself on what already exists for other customers, I've added the plural for the `de` language.

## 💻 How?

- Copy/paste what was already existing for `nl`
- Add tests in the same way
